### PR TITLE
Changed to a simpler sum.

### DIFF
--- a/sdk/metric/internal/sum_test.go
+++ b/sdk/metric/internal/sum_test.go
@@ -18,8 +18,11 @@
 package internal // import "go.opentelemetry.io/otel/sdk/metric/internal"
 
 import (
+	"context"
+	"fmt"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -58,7 +61,8 @@ func testSumAggregation[N int64 | float64](t *testing.T, agg Aggregator[N]) {
 
 	extra := make(map[attribute.Set]struct{})
 	got := make(map[attribute.Set]N)
-	for _, a := range agg.flush() {
+	flush := agg.flush()
+	for _, a := range flush {
 		got[*a.Attributes] = a.Value.(SingleValue[N]).Value
 		extra[*a.Attributes] = struct{}{}
 	}
@@ -75,5 +79,78 @@ func testSumAggregation[N int64 | float64](t *testing.T, agg Aggregator[N]) {
 	assert.Lenf(t, extra, 0, "unknown values added: %v", extra)
 }
 
-func TestInt64Sum(t *testing.T)   { testSumAggregation(t, NewSum[int64](NewInt64)) }
-func TestFloat64Sum(t *testing.T) { testSumAggregation(t, NewSum[float64](NewFloat64)) }
+func TestInt64Sum(t *testing.T)   { testSumAggregation(t, NewSum[int64]()) }
+func TestFloat64Sum(t *testing.T) { testSumAggregation(t, NewSum[float64]()) }
+
+func benchmarkSumAggregation[N int64 | float64](b *testing.B, agg Aggregator[N], count int) {
+	attrs := make([]attribute.Set, count)
+	for i := range attrs {
+		attrs[i] = attribute.NewSet(attribute.Int("value", i))
+	}
+
+	b.ResetTimer()
+
+	for n := 0; n < b.N; n++ {
+		for _, attr := range attrs {
+			agg.Aggregate(1, &attr)
+		}
+		agg.flush()
+	}
+}
+
+func BenchmarkInt64Sum(b *testing.B) {
+	for _, n := range []int{10, 50, 100} {
+		b.Run(fmt.Sprintf("count-%d", n), func(b *testing.B) {
+			benchmarkSumAggregation(b, NewSum(NewInt64), n)
+		})
+	}
+}
+func BenchmarkFloat64Sum(b *testing.B) {
+	for _, n := range []int{10, 50, 100} {
+		b.Run(fmt.Sprintf("count-%d", n), func(b *testing.B) {
+			benchmarkSumAggregation(b, NewSum(NewFloat64), n)
+		})
+	}
+}
+
+var aggsStore []Aggregation
+
+// This isn't a perfect benchmark, because we don't get consistant writes. I would probably remove it for production.
+func benchmarkSumAggregationParallel[N int64 | float64](b *testing.B, agg Aggregator[N]) {
+	attrs := make([]attribute.Set, 100)
+	for i := range attrs {
+		attrs[i] = attribute.NewSet(attribute.Int("value", i))
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	b.Cleanup(cancel)
+
+	for i := 0; i < 4; i++ {
+		go func(i int) {
+			for {
+				if ctx.Err() != nil {
+					return
+				}
+				for j := 0; j < 25; j++ {
+					agg.Aggregate(1, &attrs[i*25+j])
+				}
+			}
+		}(i)
+	}
+
+	agg.flush()
+	b.ResetTimer()
+
+	for n := 0; n < b.N; n++ {
+		aggsStore = agg.flush()
+		time.Sleep(time.Microsecond)
+
+	}
+}
+
+func BenchmarkInt64SumParallel(b *testing.B) {
+	benchmarkSumAggregationParallel(b, NewSum(NewInt64))
+}
+func BenchmarkFloat64SumParallel(b *testing.B) {
+	benchmarkSumAggregationParallel(b, NewSum(NewFloat64))
+}


### PR DESCRIPTION
This removes two allocations per unique metric, and improves run times considerably


$ benchstat bench-old  bench-new
name                    old time/op    new time/op    delta
Int64Sum/count-10-4       7.81µs ±37%    3.29µs ± 5%  -57.85%  (p=0.000 n=10+10)
Int64Sum/count-50-4       36.1µs ±31%    15.6µs ± 7%  -56.85%  (p=0.000 n=10+10)
Int64Sum/count-100-4      64.7µs ± 5%    31.0µs ± 4%  -52.17%  (p=0.000 n=8+10)
Float64Sum/count-10-4     8.22µs ±31%    3.50µs ± 2%  -57.45%  (p=0.000 n=10+10)
Float64Sum/count-50-4     36.2µs ±29%    16.6µs ± 5%  -54.13%  (p=0.000 n=9+10)
Float64Sum/count-100-4    69.9µs ±15%    33.3µs ± 4%  -52.37%  (p=0.000 n=8+10)
Int64SumParallel-4        11.4ms ±19%     0.0ms ±51%  -99.59%  (p=0.000 n=9+10)
Float64SumParallel-4      12.3ms ±31%     0.1ms ±60%  -99.57%  (p=0.000 n=10+10)

name                    old alloc/op   new alloc/op   delta
Int64Sum/count-10-4       1.57kB ± 0%    0.50kB ± 0%  -67.98%  (p=0.000 n=10+10)
Int64Sum/count-50-4       6.88kB ± 0%    2.85kB ± 0%  -58.63%  (p=0.000 n=10+10)
Int64Sum/count-100-4      13.8kB ± 0%     5.2kB ± 0%  -62.15%  (p=0.000 n=10+9)
Float64Sum/count-10-4     1.65kB ± 0%    0.58kB ± 0%  -64.68%  (p=0.000 n=10+10)
Float64Sum/count-50-4     7.28kB ± 0%    3.25kB ± 0%  -55.42%  (p=0.000 n=10+10)
Float64Sum/count-100-4    14.6kB ± 0%     6.0kB ± 0%  -58.75%  (p=0.000 n=9+10)
Int64SumParallel-4        11.9kB ±17%     1.0kB ±20%  -91.49%  (p=0.000 n=10+10)
Float64SumParallel-4      12.0kB ±19%     1.2kB ±25%  -89.91%  (p=0.000 n=10+10)

name                    old allocs/op  new allocs/op  delta
Int64Sum/count-10-4         46.0 ± 0%      12.0 ± 0%  -73.91%  (p=0.000 n=10+10)
Int64Sum/count-50-4          208 ± 0%        52 ± 0%  -75.00%  (p=0.000 n=10+10)
Int64Sum/count-100-4         409 ± 0%       102 ± 0%  -75.06%  (p=0.000 n=10+10)
Float64Sum/count-10-4       56.0 ± 0%      22.0 ± 0%  -60.71%  (p=0.000 n=10+10)
Float64Sum/count-50-4        258 ± 0%       102 ± 0%  -60.47%  (p=0.000 n=10+10)
Float64Sum/count-100-4       509 ± 0%       202 ± 0%  -60.31%  (p=0.000 n=10+10)
Int64SumParallel-4           387 ±18%        20 ±21%  -94.88%  (p=0.000 n=10+10)
Float64SumParallel-4         406 ±19%        41 ±25%  -89.92%  (p=0.000 n=10+10)