### PR TITLE
Example of options with the new generics

### DIFF
--- a/example/prometheus/main.go
+++ b/example/prometheus/main.go
@@ -60,7 +60,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	counter.Add(ctx, 5, attrs...)
+	counter.Add(ctx, 5, instrument.WithAttributes[float64](attrs...))
 
 	gauge, err := meter.Float64ObservableGauge("bar", instrument.WithDescription[float64]("a fun little gauge"))
 	if err != nil {
@@ -68,7 +68,7 @@ func main() {
 	}
 	_, err = meter.RegisterCallback(func(_ context.Context, o api.Observer) error {
 		n := -10. + rng.Float64()*(90.) // [-10, 100)
-		o.ObserveFloat64(gauge, n, attrs...)
+		o.ObserveFloat64(gauge, n, instrument.WithAttributes[float64](attrs...))
 		return nil
 	}, gauge)
 	if err != nil {
@@ -80,10 +80,10 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	histogram.Record(ctx, 23, attrs...)
-	histogram.Record(ctx, 7, attrs...)
-	histogram.Record(ctx, 101, attrs...)
-	histogram.Record(ctx, 105, attrs...)
+	histogram.Record(ctx, 23, instrument.WithAttributes[float64](attrs...))
+	histogram.Record(ctx, 7, instrument.WithAttributes[float64](attrs...))
+	histogram.Record(ctx, 101, instrument.WithAttributes[float64](attrs...))
+	histogram.Record(ctx, 105, instrument.WithAttributes[float64](attrs...))
 
 	ctx, _ = signal.NotifyContext(ctx, os.Interrupt)
 	<-ctx.Done()

--- a/example/view/main.go
+++ b/example/view/main.go
@@ -73,16 +73,16 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	counter.Add(ctx, 5, attrs...)
+	counter.Add(ctx, 5, instrument.WithAttributes[float64](attrs...))
 
 	histogram, err := meter.Float64Histogram("custom_histogram", instrument.WithDescription[float64]("a histogram with custom buckets and rename"))
 	if err != nil {
 		log.Fatal(err)
 	}
-	histogram.Record(ctx, 136, attrs...)
-	histogram.Record(ctx, 64, attrs...)
-	histogram.Record(ctx, 701, attrs...)
-	histogram.Record(ctx, 830, attrs...)
+	histogram.Record(ctx, 136, instrument.WithAttributes[float64](attrs...))
+	histogram.Record(ctx, 64, instrument.WithAttributes[float64](attrs...))
+	histogram.Record(ctx, 701, instrument.WithAttributes[float64](attrs...))
+	histogram.Record(ctx, 830, instrument.WithAttributes[float64](attrs...))
 
 	ctx, _ = signal.NotifyContext(ctx, os.Interrupt)
 	<-ctx.Done()

--- a/exporters/prometheus/exporter_test.go
+++ b/exporters/prometheus/exporter_test.go
@@ -58,9 +58,9 @@ func TestPrometheusExporter(t *testing.T) {
 					instrument.WithUnit[float64]("ms"),
 				)
 				require.NoError(t, err)
-				counter.Add(ctx, 5, attrs...)
-				counter.Add(ctx, 10.3, attrs...)
-				counter.Add(ctx, 9, attrs...)
+				counter.Add(ctx, 5, instrument.WithAttributes[float64](attrs...))
+				counter.Add(ctx, 10.3, instrument.WithAttributes[float64](attrs...))
+				counter.Add(ctx, 9, instrument.WithAttributes[float64](attrs...))
 
 				attrs2 := []attribute.KeyValue{
 					attribute.Key("A").String("D"),
@@ -68,7 +68,7 @@ func TestPrometheusExporter(t *testing.T) {
 					attribute.Key("E").Bool(true),
 					attribute.Key("F").Int(42),
 				}
-				counter.Add(ctx, 5, attrs2...)
+				counter.Add(ctx, 5, instrument.WithAttributes[float64](attrs2...))
 			},
 		},
 		{
@@ -85,8 +85,8 @@ func TestPrometheusExporter(t *testing.T) {
 					instrument.WithUnit[float64]("1"),
 				)
 				require.NoError(t, err)
-				gauge.Add(ctx, 1.0, attrs...)
-				gauge.Add(ctx, -.25, attrs...)
+				gauge.Add(ctx, 1.0, instrument.WithAttributes[float64](attrs...))
+				gauge.Add(ctx, -.25, instrument.WithAttributes[float64](attrs...))
 			},
 		},
 		{
@@ -103,10 +103,10 @@ func TestPrometheusExporter(t *testing.T) {
 					instrument.WithUnit[float64]("By"),
 				)
 				require.NoError(t, err)
-				histogram.Record(ctx, 23, attrs...)
-				histogram.Record(ctx, 7, attrs...)
-				histogram.Record(ctx, 101, attrs...)
-				histogram.Record(ctx, 105, attrs...)
+				histogram.Record(ctx, 23, instrument.WithAttributes[float64](attrs...))
+				histogram.Record(ctx, 7, instrument.WithAttributes[float64](attrs...))
+				histogram.Record(ctx, 101, instrument.WithAttributes[float64](attrs...))
+				histogram.Record(ctx, 105, instrument.WithAttributes[float64](attrs...))
 			},
 		},
 		{
@@ -130,9 +130,9 @@ func TestPrometheusExporter(t *testing.T) {
 					instrument.WithUnit[float64]("By"),
 				)
 				require.NoError(t, err)
-				counter.Add(ctx, 5, attrs...)
-				counter.Add(ctx, 10.3, attrs...)
-				counter.Add(ctx, 9, attrs...)
+				counter.Add(ctx, 5, instrument.WithAttributes[float64](attrs...))
+				counter.Add(ctx, 10.3, instrument.WithAttributes[float64](attrs...))
+				counter.Add(ctx, 9, instrument.WithAttributes[float64](attrs...))
 			},
 		},
 		{
@@ -146,21 +146,21 @@ func TestPrometheusExporter(t *testing.T) {
 				// Valid.
 				gauge, err := meter.Float64UpDownCounter("bar", instrument.WithDescription[float64]("a fun little gauge"))
 				require.NoError(t, err)
-				gauge.Add(ctx, 100, attrs...)
-				gauge.Add(ctx, -25, attrs...)
+				gauge.Add(ctx, 100, instrument.WithAttributes[float64](attrs...))
+				gauge.Add(ctx, -25, instrument.WithAttributes[float64](attrs...))
 
 				// Invalid, will be renamed.
 				gauge, err = meter.Float64UpDownCounter("invalid.gauge.name", instrument.WithDescription[float64]("a gauge with an invalid name"))
 				require.NoError(t, err)
-				gauge.Add(ctx, 100, attrs...)
+				gauge.Add(ctx, 100, instrument.WithAttributes[float64](attrs...))
 
 				counter, err := meter.Float64Counter("0invalid.counter.name", instrument.WithDescription[float64]("a counter with an invalid name"))
 				require.NoError(t, err)
-				counter.Add(ctx, 100, attrs...)
+				counter.Add(ctx, 100, instrument.WithAttributes[float64](attrs...))
 
 				histogram, err := meter.Float64Histogram("invalid.hist.name", instrument.WithDescription[float64]("a histogram with an invalid name"))
 				require.NoError(t, err)
-				histogram.Record(ctx, 23, attrs...)
+				histogram.Record(ctx, 23, instrument.WithAttributes[float64](attrs...))
 			},
 		},
 		{
@@ -176,9 +176,9 @@ func TestPrometheusExporter(t *testing.T) {
 				}
 				counter, err := meter.Float64Counter("foo", instrument.WithDescription[float64]("a simple counter"))
 				require.NoError(t, err)
-				counter.Add(ctx, 5, attrs...)
-				counter.Add(ctx, 10.3, attrs...)
-				counter.Add(ctx, 9, attrs...)
+				counter.Add(ctx, 5, instrument.WithAttributes[float64](attrs...))
+				counter.Add(ctx, 10.3, instrument.WithAttributes[float64](attrs...))
+				counter.Add(ctx, 9, instrument.WithAttributes[float64](attrs...))
 			},
 		},
 		{
@@ -197,9 +197,9 @@ func TestPrometheusExporter(t *testing.T) {
 				}
 				counter, err := meter.Float64Counter("foo", instrument.WithDescription[float64]("a simple counter"))
 				require.NoError(t, err)
-				counter.Add(ctx, 5, attrs...)
-				counter.Add(ctx, 10.3, attrs...)
-				counter.Add(ctx, 9, attrs...)
+				counter.Add(ctx, 5, instrument.WithAttributes[float64](attrs...))
+				counter.Add(ctx, 10.3, instrument.WithAttributes[float64](attrs...))
+				counter.Add(ctx, 9, instrument.WithAttributes[float64](attrs...))
 			},
 		},
 		{
@@ -215,9 +215,9 @@ func TestPrometheusExporter(t *testing.T) {
 				}
 				counter, err := meter.Float64Counter("foo", instrument.WithDescription[float64]("a simple counter"))
 				require.NoError(t, err)
-				counter.Add(ctx, 5, attrs...)
-				counter.Add(ctx, 10.3, attrs...)
-				counter.Add(ctx, 9, attrs...)
+				counter.Add(ctx, 5, instrument.WithAttributes[float64](attrs...))
+				counter.Add(ctx, 10.3, instrument.WithAttributes[float64](attrs...))
+				counter.Add(ctx, 9, instrument.WithAttributes[float64](attrs...))
 			},
 		},
 		{
@@ -235,8 +235,8 @@ func TestPrometheusExporter(t *testing.T) {
 					instrument.WithUnit[int64]("1"),
 				)
 				require.NoError(t, err)
-				gauge.Add(ctx, 2, attrs...)
-				gauge.Add(ctx, -1, attrs...)
+				gauge.Add(ctx, 2, instrument.WithAttributes[int64](attrs...))
+				gauge.Add(ctx, -1, instrument.WithAttributes[int64](attrs...))
 			},
 		},
 		{
@@ -254,8 +254,8 @@ func TestPrometheusExporter(t *testing.T) {
 					instrument.WithUnit[int64]("By"),
 				)
 				require.NoError(t, err)
-				counter.Add(ctx, 2, attrs...)
-				counter.Add(ctx, 1, attrs...)
+				counter.Add(ctx, 2, instrument.WithAttributes[int64](attrs...))
+				counter.Add(ctx, 1, instrument.WithAttributes[int64](attrs...))
 			},
 		},
 		{
@@ -273,9 +273,9 @@ func TestPrometheusExporter(t *testing.T) {
 				}
 				counter, err := meter.Float64Counter("foo", instrument.WithDescription[float64]("a simple counter"))
 				require.NoError(t, err)
-				counter.Add(ctx, 5, attrs...)
-				counter.Add(ctx, 10.3, attrs...)
-				counter.Add(ctx, 9, attrs...)
+				counter.Add(ctx, 5, instrument.WithAttributes[float64](attrs...))
+				counter.Add(ctx, 10.3, instrument.WithAttributes[float64](attrs...))
+				counter.Add(ctx, 9, instrument.WithAttributes[float64](attrs...))
 			},
 		},
 	}
@@ -388,7 +388,7 @@ func TestMultiScopes(t *testing.T) {
 			instrument.WithUnit[int64]("ms"),
 			instrument.WithDescription[int64]("meter foo counter"))
 	assert.NoError(t, err)
-	fooCounter.Add(ctx, 100, attribute.String("type", "foo"))
+	fooCounter.Add(ctx, 100, instrument.WithAttributes[int64](attribute.String("type", "foo")))
 
 	barCounter, err := provider.Meter("meterbar", otelmetric.WithInstrumentationVersion("v0.1.0")).
 		Int64Counter(
@@ -396,7 +396,7 @@ func TestMultiScopes(t *testing.T) {
 			instrument.WithUnit[int64]("ms"),
 			instrument.WithDescription[int64]("meter bar counter"))
 	assert.NoError(t, err)
-	barCounter.Add(ctx, 200, attribute.String("type", "bar"))
+	barCounter.Add(ctx, 200, instrument.WithAttributes[int64](attribute.String("type", "bar")))
 
 	file, err := os.Open("testdata/multi_scopes.txt")
 	require.NoError(t, err)
@@ -421,13 +421,13 @@ func TestDuplicateMetrics(t *testing.T) {
 					instrument.WithUnit[int64]("By"),
 					instrument.WithDescription[int64]("meter counter foo"))
 				assert.NoError(t, err)
-				fooA.Add(ctx, 100, attribute.String("A", "B"))
+				fooA.Add(ctx, 100, instrument.WithAttributes[int64](attribute.String("A", "B")))
 
 				fooB, err := meterB.Int64Counter("foo",
 					instrument.WithUnit[int64]("By"),
 					instrument.WithDescription[int64]("meter counter foo"))
 				assert.NoError(t, err)
-				fooB.Add(ctx, 100, attribute.String("A", "B"))
+				fooB.Add(ctx, 100, instrument.WithAttributes[int64](attribute.String("A", "B")))
 			},
 			possibleExpectedFiles: []string{"testdata/no_conflict_two_counters.txt"},
 		},
@@ -438,13 +438,13 @@ func TestDuplicateMetrics(t *testing.T) {
 					instrument.WithUnit[int64]("By"),
 					instrument.WithDescription[int64]("meter gauge foo"))
 				assert.NoError(t, err)
-				fooA.Add(ctx, 100, attribute.String("A", "B"))
+				fooA.Add(ctx, 100, instrument.WithAttributes[int64](attribute.String("A", "B")))
 
 				fooB, err := meterB.Int64UpDownCounter("foo",
 					instrument.WithUnit[int64]("By"),
 					instrument.WithDescription[int64]("meter gauge foo"))
 				assert.NoError(t, err)
-				fooB.Add(ctx, 100, attribute.String("A", "B"))
+				fooB.Add(ctx, 100, instrument.WithAttributes[int64](attribute.String("A", "B")))
 			},
 			possibleExpectedFiles: []string{"testdata/no_conflict_two_updowncounters.txt"},
 		},
@@ -455,13 +455,13 @@ func TestDuplicateMetrics(t *testing.T) {
 					instrument.WithUnit[int64]("By"),
 					instrument.WithDescription[int64]("meter histogram foo"))
 				assert.NoError(t, err)
-				fooA.Record(ctx, 100, attribute.String("A", "B"))
+				fooA.Record(ctx, 100, instrument.WithAttributes[int64](attribute.String("A", "B")))
 
 				fooB, err := meterB.Int64Histogram("foo",
 					instrument.WithUnit[int64]("By"),
 					instrument.WithDescription[int64]("meter histogram foo"))
 				assert.NoError(t, err)
-				fooB.Record(ctx, 100, attribute.String("A", "B"))
+				fooB.Record(ctx, 100, instrument.WithAttributes[int64](attribute.String("A", "B")))
 			},
 			possibleExpectedFiles: []string{"testdata/no_conflict_two_histograms.txt"},
 		},
@@ -472,13 +472,13 @@ func TestDuplicateMetrics(t *testing.T) {
 					instrument.WithUnit[int64]("By"),
 					instrument.WithDescription[int64]("meter a bar"))
 				assert.NoError(t, err)
-				barA.Add(ctx, 100, attribute.String("type", "bar"))
+				barA.Add(ctx, 100, instrument.WithAttributes[int64](attribute.String("type", "bar")))
 
 				barB, err := meterB.Int64Counter("bar",
 					instrument.WithUnit[int64]("By"),
 					instrument.WithDescription[int64]("meter b bar"))
 				assert.NoError(t, err)
-				barB.Add(ctx, 100, attribute.String("type", "bar"))
+				barB.Add(ctx, 100, instrument.WithAttributes[int64](attribute.String("type", "bar")))
 			},
 			possibleExpectedFiles: []string{
 				"testdata/conflict_help_two_counters_1.txt",
@@ -492,13 +492,13 @@ func TestDuplicateMetrics(t *testing.T) {
 					instrument.WithUnit[int64]("By"),
 					instrument.WithDescription[int64]("meter a bar"))
 				assert.NoError(t, err)
-				barA.Add(ctx, 100, attribute.String("type", "bar"))
+				barA.Add(ctx, 100, instrument.WithAttributes[int64](attribute.String("type", "bar")))
 
 				barB, err := meterB.Int64UpDownCounter("bar",
 					instrument.WithUnit[int64]("By"),
 					instrument.WithDescription[int64]("meter b bar"))
 				assert.NoError(t, err)
-				barB.Add(ctx, 100, attribute.String("type", "bar"))
+				barB.Add(ctx, 100, instrument.WithAttributes[int64](attribute.String("type", "bar")))
 			},
 			possibleExpectedFiles: []string{
 				"testdata/conflict_help_two_updowncounters_1.txt",
@@ -512,13 +512,13 @@ func TestDuplicateMetrics(t *testing.T) {
 					instrument.WithUnit[int64]("By"),
 					instrument.WithDescription[int64]("meter a bar"))
 				assert.NoError(t, err)
-				barA.Record(ctx, 100, attribute.String("A", "B"))
+				barA.Record(ctx, 100, instrument.WithAttributes[int64](attribute.String("A", "B")))
 
 				barB, err := meterB.Int64Histogram("bar",
 					instrument.WithUnit[int64]("By"),
 					instrument.WithDescription[int64]("meter b bar"))
 				assert.NoError(t, err)
-				barB.Record(ctx, 100, attribute.String("A", "B"))
+				barB.Record(ctx, 100, instrument.WithAttributes[int64](attribute.String("A", "B")))
 			},
 			possibleExpectedFiles: []string{
 				"testdata/conflict_help_two_histograms_1.txt",
@@ -532,13 +532,13 @@ func TestDuplicateMetrics(t *testing.T) {
 					instrument.WithUnit[int64]("By"),
 					instrument.WithDescription[int64]("meter bar"))
 				assert.NoError(t, err)
-				bazA.Add(ctx, 100, attribute.String("type", "bar"))
+				bazA.Add(ctx, 100, instrument.WithAttributes[int64](attribute.String("type", "bar")))
 
 				bazB, err := meterB.Int64Counter("bar",
 					instrument.WithUnit[int64]("ms"),
 					instrument.WithDescription[int64]("meter bar"))
 				assert.NoError(t, err)
-				bazB.Add(ctx, 100, attribute.String("type", "bar"))
+				bazB.Add(ctx, 100, instrument.WithAttributes[int64](attribute.String("type", "bar")))
 			},
 			options:               []Option{WithoutUnits()},
 			possibleExpectedFiles: []string{"testdata/conflict_unit_two_counters.txt"},
@@ -550,13 +550,13 @@ func TestDuplicateMetrics(t *testing.T) {
 					instrument.WithUnit[int64]("By"),
 					instrument.WithDescription[int64]("meter gauge bar"))
 				assert.NoError(t, err)
-				barA.Add(ctx, 100, attribute.String("type", "bar"))
+				barA.Add(ctx, 100, instrument.WithAttributes[int64](attribute.String("type", "bar")))
 
 				barB, err := meterB.Int64UpDownCounter("bar",
 					instrument.WithUnit[int64]("ms"),
 					instrument.WithDescription[int64]("meter gauge bar"))
 				assert.NoError(t, err)
-				barB.Add(ctx, 100, attribute.String("type", "bar"))
+				barB.Add(ctx, 100, instrument.WithAttributes[int64](attribute.String("type", "bar")))
 			},
 			options:               []Option{WithoutUnits()},
 			possibleExpectedFiles: []string{"testdata/conflict_unit_two_updowncounters.txt"},
@@ -568,13 +568,13 @@ func TestDuplicateMetrics(t *testing.T) {
 					instrument.WithUnit[int64]("By"),
 					instrument.WithDescription[int64]("meter histogram bar"))
 				assert.NoError(t, err)
-				barA.Record(ctx, 100, attribute.String("A", "B"))
+				barA.Record(ctx, 100, instrument.WithAttributes[int64](attribute.String("A", "B")))
 
 				barB, err := meterB.Int64Histogram("bar",
 					instrument.WithUnit[int64]("ms"),
 					instrument.WithDescription[int64]("meter histogram bar"))
 				assert.NoError(t, err)
-				barB.Record(ctx, 100, attribute.String("A", "B"))
+				barB.Record(ctx, 100, instrument.WithAttributes[int64](attribute.String("A", "B")))
 			},
 			options:               []Option{WithoutUnits()},
 			possibleExpectedFiles: []string{"testdata/conflict_unit_two_histograms.txt"},
@@ -586,13 +586,13 @@ func TestDuplicateMetrics(t *testing.T) {
 					instrument.WithUnit[int64]("By"),
 					instrument.WithDescription[int64]("meter foo"))
 				assert.NoError(t, err)
-				counter.Add(ctx, 100, attribute.String("type", "foo"))
+				counter.Add(ctx, 100, instrument.WithAttributes[int64](attribute.String("type", "foo")))
 
 				gauge, err := meterA.Int64UpDownCounter("foo_total",
 					instrument.WithUnit[int64]("By"),
 					instrument.WithDescription[int64]("meter foo"))
 				assert.NoError(t, err)
-				gauge.Add(ctx, 200, attribute.String("type", "foo"))
+				gauge.Add(ctx, 200, instrument.WithAttributes[int64](attribute.String("type", "foo")))
 			},
 			options: []Option{WithoutUnits()},
 			possibleExpectedFiles: []string{
@@ -607,13 +607,13 @@ func TestDuplicateMetrics(t *testing.T) {
 					instrument.WithUnit[int64]("By"),
 					instrument.WithDescription[int64]("meter gauge foo"))
 				assert.NoError(t, err)
-				fooA.Add(ctx, 100, attribute.String("A", "B"))
+				fooA.Add(ctx, 100, instrument.WithAttributes[int64](attribute.String("A", "B")))
 
 				fooHistogramA, err := meterA.Int64Histogram("foo",
 					instrument.WithUnit[int64]("By"),
 					instrument.WithDescription[int64]("meter histogram foo"))
 				assert.NoError(t, err)
-				fooHistogramA.Record(ctx, 100, attribute.String("A", "B"))
+				fooHistogramA.Record(ctx, 100, instrument.WithAttributes[int64](attribute.String("A", "B")))
 			},
 			possibleExpectedFiles: []string{
 				"testdata/conflict_type_histogram_and_updowncounter_1.txt",

--- a/internal/global/instruments.go
+++ b/internal/global/instruments.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"sync/atomic"
 
-	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric/embedded"
 	"go.opentelemetry.io/otel/metric/instrument"
 )
@@ -106,9 +105,9 @@ type counter[N int64 | float64] struct {
 	opts []instrument.CounterOption[N]
 }
 
-func (i *counter[N]) Add(ctx context.Context, incr N, attrs ...attribute.KeyValue) {
+func (i *counter[N]) Add(ctx context.Context, incr N, opts ...instrument.AddOption[N]) {
 	if ctr := i.Load(); ctr != nil {
-		ctr.(instrument.Counter[N]).Add(ctx, incr, attrs...)
+		ctr.(instrument.Counter[N]).Add(ctx, incr, opts...)
 	}
 }
 
@@ -120,9 +119,9 @@ type upDownCounter[N int64 | float64] struct {
 	opts []instrument.UpDownCounterOption[N]
 }
 
-func (i *upDownCounter[N]) Add(ctx context.Context, incr N, attrs ...attribute.KeyValue) {
+func (i *upDownCounter[N]) Add(ctx context.Context, incr N, opts ...instrument.AddOption[N]) {
 	if ctr := i.Load(); ctr != nil {
-		ctr.(instrument.UpDownCounter[N]).Add(ctx, incr, attrs...)
+		ctr.(instrument.UpDownCounter[N]).Add(ctx, incr, opts...)
 	}
 }
 
@@ -134,8 +133,8 @@ type histogram[N int64 | float64] struct {
 	opts []instrument.HistogramOption[N]
 }
 
-func (i *histogram[N]) Record(ctx context.Context, x N, attrs ...attribute.KeyValue) {
+func (i *histogram[N]) Record(ctx context.Context, x N, opts ...instrument.RecordOption[N]) {
 	if ctr := i.Load(); ctr != nil {
-		ctr.(instrument.Histogram[N]).Record(ctx, x, attrs...)
+		ctr.(instrument.Histogram[N]).Record(ctx, x, opts...)
 	}
 }

--- a/internal/global/instruments_test.go
+++ b/internal/global/instruments_test.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric/embedded"
 	"go.opentelemetry.io/otel/metric/instrument"
 	"go.opentelemetry.io/otel/metric/noop"
@@ -153,9 +152,9 @@ type testCountingInstrument[N int64 | float64] struct {
 func (i *testCountingInstrument[N]) observe() {
 	i.count++
 }
-func (i *testCountingInstrument[N]) Add(context.Context, N, ...attribute.KeyValue) {
+func (i *testCountingInstrument[N]) Add(context.Context, N, ...instrument.AddOption[N]) {
 	i.count++
 }
-func (i *testCountingInstrument[N]) Record(context.Context, N, ...attribute.KeyValue) {
+func (i *testCountingInstrument[N]) Record(context.Context, N, ...instrument.RecordOption[N]) {
 	i.count++
 }

--- a/internal/global/meter_types_test.go
+++ b/internal/global/meter_types_test.go
@@ -17,7 +17,6 @@ package global // import "go.opentelemetry.io/otel/internal/global"
 import (
 	"context"
 
-	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/metric/embedded"
 	"go.opentelemetry.io/otel/metric/instrument"
@@ -157,14 +156,14 @@ type observationRecorder struct {
 	ctx context.Context
 }
 
-func (o observationRecorder) ObserveFloat64(i instrument.ObservableT[float64], value float64, attr ...attribute.KeyValue) {
+func (o observationRecorder) ObserveFloat64(i instrument.ObservableT[float64], value float64, opts ...instrument.ObserveOption[float64]) {
 	iImpl, ok := i.(*testCountingInstrument[float64])
 	if ok {
 		iImpl.observe()
 	}
 }
 
-func (o observationRecorder) ObserveInt64(i instrument.ObservableT[int64], value int64, attr ...attribute.KeyValue) {
+func (o observationRecorder) ObserveInt64(i instrument.ObservableT[int64], value int64, opts ...instrument.ObserveOption[int64]) {
 	iImpl, ok := i.(*testCountingInstrument[int64])
 	if ok {
 		iImpl.observe()

--- a/metric/example_test.go
+++ b/metric/example_test.go
@@ -46,6 +46,7 @@ func ExampleMeter_synchronous() {
 func ExampleMeter_asynchronous_single() {
 	meter := otel.Meter("go.opentelemetry.io/otel/metric#AsyncExample")
 
+	attrs := attribute.NewSet(attribute.Int("disk.id", 3))
 	_, err := meter.Int64ObservableGauge(
 		"DiskUsage",
 		instrument.WithUnit[int64]("By"),
@@ -63,7 +64,7 @@ func ExampleMeter_asynchronous_single() {
 			//
 			// For demonstration purpose, a static value is used here.
 			usage := 75000
-			obsrv.Observe(int64(usage), attribute.Int("disk.id", 3))
+			obsrv.Observe(int64(usage), instrument.WithAttributeSet[int64](attrs))
 			return nil
 		}),
 	)

--- a/metric/instrument/async.go
+++ b/metric/instrument/async.go
@@ -17,7 +17,6 @@ package instrument // import "go.opentelemetry.io/otel/metric/instrument"
 import (
 	"context"
 
-	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric/embedded"
 )
 
@@ -210,7 +209,7 @@ type ObserverT[N int64 | float64] interface {
 	embedded.ObserverT[N]
 
 	// Observe records the value with attributes.
-	Observe(value N, attributes ...attribute.KeyValue)
+	Observe(value N, opts ...ObserveOption[N])
 }
 
 // Callback is a function registered with a Meter that makes observations

--- a/metric/instrument/async_test.go
+++ b/metric/instrument/async_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric/embedded"
 )
 
@@ -95,6 +94,6 @@ type observer[N int64 | float64] struct {
 	got N
 }
 
-func (o *observer[N]) Observe(v N, _ ...attribute.KeyValue) {
+func (o *observer[N]) Observe(v N, _ ...ObserveOption[N]) {
 	o.got = v
 }

--- a/metric/instrument/config.go
+++ b/metric/instrument/config.go
@@ -1,0 +1,182 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package instrument // import "go.opentelemetry.io/otel/metric/instrument"
+
+import "go.opentelemetry.io/otel/attribute"
+
+// AddOption[N] applies options to an addition measurement. See
+// [MeasurementOption] for other options that can be used as a AddOption[N].
+type AddOption[N int64 | float64] interface {
+	applyAdd(AddConfig[N]) AddConfig[N]
+}
+
+// AddConfig[N] contains options for an addition measurement.
+type AddConfig[N int64 | float64] struct {
+	attrs attribute.Set
+}
+
+// NewAddConfig[N] returns a new [AddConfig[N]] with all opts applied.
+func NewAddConfig[N int64 | float64](opts []AddOption[N]) AddConfig[N] {
+	config := AddConfig[N]{attrs: *attribute.EmptySet()}
+	for _, o := range opts {
+		config = o.applyAdd(config)
+	}
+	return config
+}
+
+// Attributes returns the configured attribute set.
+func (c AddConfig[N]) Attributes() attribute.Set {
+	return c.attrs
+}
+
+// RecordOption[N] applies options to an addition measurement. See
+// [MeasurementOption] for other options that can be used as a
+// RecordOption.
+type RecordOption[N int64 | float64] interface {
+	applyRecord(RecordConfig[N]) RecordConfig[N]
+}
+
+// RecordConfig[N] contains options for an int64 recorded measurement.
+type RecordConfig[N int64 | float64] struct {
+	attrs attribute.Set
+}
+
+// NewRecordConfig[N] returns a new [RecordConfig[N]] with all opts
+// applied.
+func NewRecordConfig[N int64 | float64](opts []RecordOption[N]) RecordConfig[N] {
+	config := RecordConfig[N]{attrs: *attribute.EmptySet()}
+	for _, o := range opts {
+		config = o.applyRecord(config)
+	}
+	return config
+}
+
+// Attributes returns the configured attribute set.
+func (c RecordConfig[N]) Attributes() attribute.Set {
+	return c.attrs
+}
+
+// ObserveOption[N] applies options to an addition measurement. See
+// [MeasurementOption] for other options that can be used as a
+// ObserveOption[N].
+type ObserveOption[N int64 | float64] interface {
+	applyObserve(ObserveConfig[N]) ObserveConfig[N]
+}
+
+// ObserveConfig[N] contains options for an int64 observed measurement.
+type ObserveConfig[N int64 | float64] struct {
+	attrs attribute.Set
+}
+
+// NewObserveConfig[N] returns a new [ObserveConfig[N]] with all opts
+// applied.
+func NewObserveConfig[N int64 | float64](opts []ObserveOption[N]) ObserveConfig[N] {
+	config := ObserveConfig[N]{attrs: *attribute.EmptySet()}
+	for _, o := range opts {
+		config = o.applyObserve(config)
+	}
+	return config
+}
+
+// Attributes returns the configured attribute set.
+func (c ObserveConfig[N]) Attributes() attribute.Set {
+	return c.attrs
+}
+
+// MeasurementOption[N] applies options to all instrument measurement.
+type MeasurementOption[N int64 | float64] interface {
+	AddOption[N]
+	RecordOption[N]
+	ObserveOption[N]
+}
+
+type attrOpt[N int64 | float64] struct {
+	set attribute.Set
+}
+
+// mergeSets returns the union of keys between a and b. Any duplicate keys will
+// use the value associated with b.
+func mergeSets(a, b attribute.Set) attribute.Set {
+	// NewMergeIterator uses the first value for any duplicates.
+	iter := attribute.NewMergeIterator(&b, &a)
+	merged := make([]attribute.KeyValue, 0, a.Len()+b.Len())
+	for iter.Next() {
+		merged = append(merged, iter.Attribute())
+	}
+	return attribute.NewSet(merged...)
+}
+
+func (o attrOpt[N]) applyAdd(c AddConfig[N]) AddConfig[N] {
+	switch {
+	case o.set.Len() == 0:
+	case c.attrs.Len() == 0:
+		c.attrs = o.set
+	default:
+		c.attrs = mergeSets(c.attrs, o.set)
+	}
+	return c
+}
+
+func (o attrOpt[N]) applyRecord(c RecordConfig[N]) RecordConfig[N] {
+	switch {
+	case o.set.Len() == 0:
+	case c.attrs.Len() == 0:
+		c.attrs = o.set
+	default:
+		c.attrs = mergeSets(c.attrs, o.set)
+	}
+	return c
+}
+func (o attrOpt[N]) applyObserve(c ObserveConfig[N]) ObserveConfig[N] {
+	switch {
+	case o.set.Len() == 0:
+	case c.attrs.Len() == 0:
+		c.attrs = o.set
+	default:
+		c.attrs = mergeSets(c.attrs, o.set)
+	}
+	return c
+}
+
+// WithAttributeSet sets the attribute Set associated with a measurement is
+// made with.
+//
+// If multiple WithAttributeSet or WithAttributes options are passed the
+// attributes will be merged together in the order they are passed. Attributes
+// with duplicate keys will use the last value passed.
+func WithAttributeSet[N int64 | float64](attributes attribute.Set) MeasurementOption[N] {
+	return attrOpt[N]{set: attributes}
+}
+
+// WithAttribute converts attributes into an attribute Set and sets the Set
+// to be associated with a measurement. This is shorthand for:
+//
+//	cp := make([]attribute.KeyValue, len(attributes))
+//	copy(cp, attributes)
+//	WithAttributes(attribute.NewSet(cp...))
+//
+// [attribute.NewSet] may modify the passed attributes so this will make a copy of
+// attributes before creating a set in order to ensure this function is
+// concurrent safe. This makes this option function less optimized in
+// comparison to [WithAttributeSet]. That option function should be perfered
+// for performance sensitive code.
+//
+// See [WithAttributeSet] for information about how multiple WithAttributes are
+// merged.
+func WithAttributes[N int64 | float64](attributes ...attribute.KeyValue) MeasurementOption[N] {
+	cp := make([]attribute.KeyValue, len(attributes))
+	copy(cp, attributes)
+	return attrOpt[N]{set: attribute.NewSet(cp...)}
+}

--- a/metric/instrument/sync.go
+++ b/metric/instrument/sync.go
@@ -17,7 +17,6 @@ package instrument // import "go.opentelemetry.io/otel/metric/instrument"
 import (
 	"context"
 
-	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric/embedded"
 )
 
@@ -31,7 +30,7 @@ type Counter[N int64 | float64] interface {
 	embedded.Counter[N]
 
 	// Add records a change to the counter.
-	Add(ctx context.Context, incr N, attrs ...attribute.KeyValue)
+	Add(ctx context.Context, incr N, opts ...AddOption[N])
 }
 
 // CounterConfig contains options for synchronous counter instruments that
@@ -77,7 +76,7 @@ type UpDownCounter[N int64 | float64] interface {
 	embedded.UpDownCounter[N]
 
 	// Add records a change to the counter.
-	Add(ctx context.Context, incr N, attrs ...attribute.KeyValue)
+	Add(ctx context.Context, incr N, opts ...AddOption[N])
 }
 
 // UpDownCounterConfig contains options for synchronous counter
@@ -124,7 +123,7 @@ type Histogram[N int64 | float64] interface {
 	embedded.Histogram[N]
 
 	// Record adds an additional value to the distribution.
-	Record(ctx context.Context, incr N, attrs ...attribute.KeyValue)
+	Record(ctx context.Context, incr N, opts ...RecordOption[N])
 }
 
 // HistogramConfig contains options for synchronous Histogram instruments.

--- a/metric/meter.go
+++ b/metric/meter.go
@@ -17,7 +17,6 @@ package metric // import "go.opentelemetry.io/otel/metric"
 import (
 	"context"
 
-	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric/embedded"
 	"go.opentelemetry.io/otel/metric/instrument"
 )
@@ -142,9 +141,9 @@ type Observer interface {
 	embedded.Observer
 
 	// ObserveFloat64 records the float64 value with attributes for obsrv.
-	ObserveFloat64(obsrv instrument.ObservableT[float64], value float64, attributes ...attribute.KeyValue)
+	ObserveFloat64(obsrv instrument.ObservableT[float64], value float64, opts ...instrument.ObserveOption[float64])
 	// ObserveInt64 records the int64 value with attributes for obsrv.
-	ObserveInt64(obsrv instrument.ObservableT[int64], value int64, attributes ...attribute.KeyValue)
+	ObserveInt64(obsrv instrument.ObservableT[int64], value int64, opts ...instrument.ObserveOption[int64])
 }
 
 // Registration is an token representing the unique registration of a callback

--- a/metric/noop/noop.go
+++ b/metric/noop/noop.go
@@ -26,7 +26,6 @@ package noop // import "go.opentelemetry.io/otel/metric/noop"
 import (
 	"context"
 
-	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/metric/embedded"
 	"go.opentelemetry.io/otel/metric/instrument"
@@ -153,11 +152,11 @@ func (Meter) RegisterCallback(metric.Callback, ...instrument.Observable) (metric
 type Observer struct{ embedded.Observer }
 
 // ObserveFloat64 performs no operation.
-func (Observer) ObserveFloat64(instrument.ObservableT[float64], float64, ...attribute.KeyValue) {
+func (Observer) ObserveFloat64(instrument.ObservableT[float64], float64, ...instrument.ObserveOption[float64]) {
 }
 
 // ObserveInt64 performs no operation.
-func (Observer) ObserveInt64(instrument.ObservableT[int64], int64, ...attribute.KeyValue) {
+func (Observer) ObserveInt64(instrument.ObservableT[int64], int64, ...instrument.ObserveOption[int64]) {
 }
 
 // Registration is the registration of a Callback with a No-Op Meter.
@@ -173,21 +172,21 @@ func (Registration) Unregister() error { return nil }
 type Counter[N int64 | float64] struct{ embedded.Counter[N] }
 
 // Add performs no operation.
-func (Counter[N]) Add(context.Context, N, ...attribute.KeyValue) {}
+func (Counter[N]) Add(context.Context, N, ...instrument.AddOption[N]) {}
 
 // UpDownCounter is an OpenTelemetry UpDownCounter used to record measurements.
 // It produces no telemetry.
 type UpDownCounter[N int64 | float64] struct{ embedded.UpDownCounter[N] }
 
 // Add performs no operation.
-func (UpDownCounter[N]) Add(context.Context, N, ...attribute.KeyValue) {}
+func (UpDownCounter[N]) Add(context.Context, N, ...instrument.AddOption[N]) {}
 
 // Histogram is an OpenTelemetry Histogram used to record measurements. It
 // produces no telemetry.
 type Histogram[N int64 | float64] struct{ embedded.Histogram[N] }
 
 // Record performs no operation.
-func (Histogram[N]) Record(context.Context, N, ...attribute.KeyValue) {}
+func (Histogram[N]) Record(context.Context, N, ...instrument.RecordOption[N]) {}
 
 // ObservableCounter is an OpenTelemetry ObservableCounter used to record
 // measurements. It produces no telemetry.
@@ -214,4 +213,4 @@ type ObservableUpDownCounter[N int64 | float64] struct {
 type ObserverT[N int64 | float64] struct{ embedded.ObserverT[N] }
 
 // Observe performs no operation.
-func (ObserverT[N]) Observe(N, ...attribute.KeyValue) {}
+func (ObserverT[N]) Observe(N, ...instrument.ObserveOption[N]) {}

--- a/sdk/metric/benchmark_test.go
+++ b/sdk/metric/benchmark_test.go
@@ -45,16 +45,18 @@ func BenchmarkCounterAddNoAttrs(b *testing.B) {
 func BenchmarkCounterAddOneAttr(b *testing.B) {
 	ctx, _, cntr := benchCounter(b)
 
+	attrs := attribute.NewSet(attribute.String("K", "V"))
 	for i := 0; i < b.N; i++ {
-		cntr.Add(ctx, 1, attribute.String("K", "V"))
+		cntr.Add(ctx, 1, instrument.WithAttributeSet[int64](attrs))
 	}
 }
 
 func BenchmarkCounterAddOneInvalidAttr(b *testing.B) {
 	ctx, _, cntr := benchCounter(b)
 
+	attrs := attribute.NewSet(attribute.String("", "V"), attribute.String("K", "V"))
 	for i := 0; i < b.N; i++ {
-		cntr.Add(ctx, 1, attribute.String("", "V"), attribute.String("K", "V"))
+		cntr.Add(ctx, 1, instrument.WithAttributeSet[int64](attrs))
 	}
 }
 
@@ -62,7 +64,8 @@ func BenchmarkCounterAddSingleUseAttrs(b *testing.B) {
 	ctx, _, cntr := benchCounter(b)
 
 	for i := 0; i < b.N; i++ {
-		cntr.Add(ctx, 1, attribute.Int("K", i))
+		attrs := attribute.NewSet(attribute.Int("K", i))
+		cntr.Add(ctx, 1, instrument.WithAttributeSet[int64](attrs))
 	}
 }
 
@@ -70,7 +73,8 @@ func BenchmarkCounterAddSingleUseInvalidAttrs(b *testing.B) {
 	ctx, _, cntr := benchCounter(b)
 
 	for i := 0; i < b.N; i++ {
-		cntr.Add(ctx, 1, attribute.Int("", i), attribute.Int("K", i))
+		attrs := attribute.NewSet(attribute.Int("", i), attribute.Int("K", i))
+		cntr.Add(ctx, 1, instrument.WithAttributeSet[int64](attrs))
 	}
 }
 
@@ -83,15 +87,17 @@ func BenchmarkCounterAddSingleUseFilteredAttrs(b *testing.B) {
 	))
 
 	for i := 0; i < b.N; i++ {
-		cntr.Add(ctx, 1, attribute.Int("L", i), attribute.Int("K", i))
+		attrs := attribute.NewSet(attribute.Int("L", i), attribute.Int("K", i))
+		cntr.Add(ctx, 1, instrument.WithAttributeSet[int64](attrs))
 	}
 }
 
 func BenchmarkCounterCollectOneAttr(b *testing.B) {
 	ctx, rdr, cntr := benchCounter(b)
 
+	attrs := attribute.NewSet(attribute.Int("K", 1))
 	for i := 0; i < b.N; i++ {
-		cntr.Add(ctx, 1, attribute.Int("K", 1))
+		cntr.Add(ctx, 1, instrument.WithAttributeSet[int64](attrs))
 
 		_ = rdr.Collect(ctx, nil)
 	}
@@ -102,7 +108,8 @@ func BenchmarkCounterCollectTenAttrs(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		for j := 0; j < 10; j++ {
-			cntr.Add(ctx, 1, attribute.Int("K", j))
+			attrs := attribute.NewSet(attribute.Int("K", j))
+			cntr.Add(ctx, 1, instrument.WithAttributeSet[int64](attrs))
 		}
 		_ = rdr.Collect(ctx, nil)
 	}

--- a/sdk/metric/instrument_test.go
+++ b/sdk/metric/instrument_test.go
@@ -23,12 +23,12 @@ import (
 )
 
 func BenchmarkInstrument(b *testing.B) {
-	attr := func(id int) []attribute.KeyValue {
-		return []attribute.KeyValue{
+	attr := func(id int) attribute.Set {
+		return attribute.NewSet(
 			attribute.String("user", "Alice"),
 			attribute.Bool("admin", true),
 			attribute.Int("id", id),
-		}
+		)
 	}
 
 	b.Run("instrumentImpl/aggregate", func(b *testing.B) {

--- a/sdk/metric/internal/aggregator_example_test.go
+++ b/sdk/metric/internal/aggregator_example_test.go
@@ -38,7 +38,7 @@ func (p *meter) Int64Counter(string, ...instrument.CounterOption[int64]) (instru
 	// here these are determined to be a cumulative sum.
 
 	aggregator := NewCumulativeSum[int64](true)
-	count := inst{aggregateFunc: aggregator.Aggregate}
+	count := inst[int64]{aggregateFunc: aggregator.Aggregate}
 
 	p.aggregations = append(p.aggregations, aggregator.Aggregation())
 
@@ -55,7 +55,7 @@ func (p *meter) Int64UpDownCounter(string, ...instrument.UpDownCounterOption[int
 	// aggregation (the temporality does not affect the produced aggregations).
 
 	aggregator := NewLastValue[int64]()
-	upDownCount := inst{aggregateFunc: aggregator.Aggregate}
+	upDownCount := inst[int64]{aggregateFunc: aggregator.Aggregate}
 
 	p.aggregations = append(p.aggregations, aggregator.Aggregation())
 
@@ -75,7 +75,7 @@ func (p *meter) Int64Histogram(string, ...instrument.HistogramOption[int64]) (in
 		Boundaries: []float64{0, 5, 10, 25, 50, 75, 100, 250, 500, 1000},
 		NoMinMax:   false,
 	})
-	hist := inst{aggregateFunc: aggregator.Aggregate}
+	hist := inst[int64]{aggregateFunc: aggregator.Aggregate}
 
 	p.aggregations = append(p.aggregations, aggregator.Aggregation())
 
@@ -86,7 +86,7 @@ func (p *meter) Int64Histogram(string, ...instrument.HistogramOption[int64]) (in
 
 // inst is a generalized int64 synchronous counter, up-down counter, and
 // histogram used for demonstration purposes only.
-type inst struct {
+type inst[N int64 | float64] struct {
 	aggregateFunc func(int64, attribute.Set)
 
 	embedded.Counter[int64]
@@ -94,8 +94,8 @@ type inst struct {
 	embedded.Histogram[int64]
 }
 
-func (inst) Add(context.Context, int64, ...attribute.KeyValue)    {}
-func (inst) Record(context.Context, int64, ...attribute.KeyValue) {}
+func (inst[N]) Add(context.Context, int64, ...instrument.AddOption[N])       {}
+func (inst[N]) Record(context.Context, int64, ...instrument.RecordOption[N]) {}
 
 func Example() {
 	m := meter{}

--- a/sdk/metric/meter.go
+++ b/sdk/metric/meter.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"fmt"
 
-	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/internal/global"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/metric/embedded"
@@ -297,7 +296,7 @@ var (
 	errUnregObserver   = errors.New("observable instrument not registered for callback")
 )
 
-func (r observer) ObserveFloat64(o instrument.ObservableT[float64], v float64, a ...attribute.KeyValue) {
+func (r observer) ObserveFloat64(o instrument.ObservableT[float64], v float64, opts ...instrument.ObserveOption[float64]) {
 	var oImpl *observable[float64]
 	switch conv := o.(type) {
 	case *observable[float64]:
@@ -326,10 +325,11 @@ func (r observer) ObserveFloat64(o instrument.ObservableT[float64], v float64, a
 		)
 		return
 	}
-	oImpl.observe(v, a)
+	cfg := instrument.NewObserveConfig(opts)
+	oImpl.observe(v, cfg.Attributes())
 }
 
-func (r observer) ObserveInt64(o instrument.ObservableT[int64], v int64, a ...attribute.KeyValue) {
+func (r observer) ObserveInt64(o instrument.ObservableT[int64], v int64, opts ...instrument.ObserveOption[int64]) {
 	var oImpl *observable[int64]
 	switch conv := o.(type) {
 	case *observable[int64]:
@@ -358,7 +358,8 @@ func (r observer) ObserveInt64(o instrument.ObservableT[int64], v int64, a ...at
 		)
 		return
 	}
-	oImpl.observe(v, a)
+	cfg := instrument.NewObserveConfig(opts)
+	oImpl.observe(v, cfg.Attributes())
 }
 
 type noopRegister struct{ embedded.Registration }
@@ -425,6 +426,7 @@ type observerT[N int64 | float64] struct {
 	*observable[N]
 }
 
-func (o observerT[N]) Observe(val N, attrs ...attribute.KeyValue) {
-	o.observe(val, attrs)
+func (o observerT[N]) Observe(val N, opts ...instrument.ObserveOption[N]) {
+	cfg := instrument.NewObserveConfig(opts)
+	o.observe(val, cfg.Attributes())
 }

--- a/sdk/metric/meter_test.go
+++ b/sdk/metric/meter_test.go
@@ -168,7 +168,7 @@ func TestCallbackUnregisterConcurrency(t *testing.T) {
 
 // Instruments should produce correct ResourceMetrics.
 func TestMeterCreatesInstruments(t *testing.T) {
-	attrs := []attribute.KeyValue{attribute.String("name", "alice")}
+	attrs := attribute.NewSet(attribute.String("name", "alice"))
 	testCases := []struct {
 		name string
 		fn   func(*testing.T, metric.Meter)
@@ -178,7 +178,7 @@ func TestMeterCreatesInstruments(t *testing.T) {
 			name: "ObservableInt64Count",
 			fn: func(t *testing.T, m metric.Meter) {
 				cback := func(_ context.Context, o instrument.ObserverT[int64]) error {
-					o.Observe(4, attrs...)
+					o.Observe(4, instrument.WithAttributeSet[int64](attrs))
 					return nil
 				}
 				ctr, err := m.Int64ObservableCounter("aint", instrument.WithCallback[int64](cback))
@@ -195,7 +195,7 @@ func TestMeterCreatesInstruments(t *testing.T) {
 					Temporality: metricdata.CumulativeTemporality,
 					IsMonotonic: true,
 					DataPoints: []metricdata.DataPoint[int64]{
-						{Attributes: attribute.NewSet(attrs...), Value: 4},
+						{Attributes: attrs, Value: 4},
 						{Value: 3},
 					},
 				},
@@ -205,7 +205,7 @@ func TestMeterCreatesInstruments(t *testing.T) {
 			name: "ObservableInt64UpDownCount",
 			fn: func(t *testing.T, m metric.Meter) {
 				cback := func(_ context.Context, o instrument.ObserverT[int64]) error {
-					o.Observe(4, attrs...)
+					o.Observe(4, instrument.WithAttributeSet[int64](attrs))
 					return nil
 				}
 				ctr, err := m.Int64ObservableUpDownCounter("aint", instrument.WithCallback[int64](cback))
@@ -222,7 +222,7 @@ func TestMeterCreatesInstruments(t *testing.T) {
 					Temporality: metricdata.CumulativeTemporality,
 					IsMonotonic: false,
 					DataPoints: []metricdata.DataPoint[int64]{
-						{Attributes: attribute.NewSet(attrs...), Value: 4},
+						{Attributes: attrs, Value: 4},
 						{Value: 11},
 					},
 				},
@@ -232,7 +232,7 @@ func TestMeterCreatesInstruments(t *testing.T) {
 			name: "ObservableInt64Gauge",
 			fn: func(t *testing.T, m metric.Meter) {
 				cback := func(_ context.Context, o instrument.ObserverT[int64]) error {
-					o.Observe(4, attrs...)
+					o.Observe(4, instrument.WithAttributeSet[int64](attrs))
 					return nil
 				}
 				gauge, err := m.Int64ObservableGauge("agauge", instrument.WithCallback[int64](cback))
@@ -247,7 +247,7 @@ func TestMeterCreatesInstruments(t *testing.T) {
 				Name: "agauge",
 				Data: metricdata.Gauge[int64]{
 					DataPoints: []metricdata.DataPoint[int64]{
-						{Attributes: attribute.NewSet(attrs...), Value: 4},
+						{Attributes: attrs, Value: 4},
 						{Value: 11},
 					},
 				},
@@ -257,7 +257,7 @@ func TestMeterCreatesInstruments(t *testing.T) {
 			name: "ObservableFloat64Count",
 			fn: func(t *testing.T, m metric.Meter) {
 				cback := func(_ context.Context, o instrument.ObserverT[float64]) error {
-					o.Observe(4, attrs...)
+					o.Observe(4, instrument.WithAttributeSet[float64](attrs))
 					return nil
 				}
 				ctr, err := m.Float64ObservableCounter("afloat", instrument.WithCallback[float64](cback))
@@ -274,7 +274,7 @@ func TestMeterCreatesInstruments(t *testing.T) {
 					Temporality: metricdata.CumulativeTemporality,
 					IsMonotonic: true,
 					DataPoints: []metricdata.DataPoint[float64]{
-						{Attributes: attribute.NewSet(attrs...), Value: 4},
+						{Attributes: attrs, Value: 4},
 						{Value: 3},
 					},
 				},
@@ -284,7 +284,7 @@ func TestMeterCreatesInstruments(t *testing.T) {
 			name: "ObservableFloat64UpDownCount",
 			fn: func(t *testing.T, m metric.Meter) {
 				cback := func(_ context.Context, o instrument.ObserverT[float64]) error {
-					o.Observe(4, attrs...)
+					o.Observe(4, instrument.WithAttributeSet[float64](attrs))
 					return nil
 				}
 				ctr, err := m.Float64ObservableUpDownCounter("afloat", instrument.WithCallback[float64](cback))
@@ -301,7 +301,7 @@ func TestMeterCreatesInstruments(t *testing.T) {
 					Temporality: metricdata.CumulativeTemporality,
 					IsMonotonic: false,
 					DataPoints: []metricdata.DataPoint[float64]{
-						{Attributes: attribute.NewSet(attrs...), Value: 4},
+						{Attributes: attrs, Value: 4},
 						{Value: 11},
 					},
 				},
@@ -311,7 +311,7 @@ func TestMeterCreatesInstruments(t *testing.T) {
 			name: "ObservableFloat64Gauge",
 			fn: func(t *testing.T, m metric.Meter) {
 				cback := func(_ context.Context, o instrument.ObserverT[float64]) error {
-					o.Observe(4, attrs...)
+					o.Observe(4, instrument.WithAttributeSet[float64](attrs))
 					return nil
 				}
 				gauge, err := m.Float64ObservableGauge("agauge", instrument.WithCallback[float64](cback))
@@ -326,7 +326,7 @@ func TestMeterCreatesInstruments(t *testing.T) {
 				Name: "agauge",
 				Data: metricdata.Gauge[float64]{
 					DataPoints: []metricdata.DataPoint[float64]{
-						{Attributes: attribute.NewSet(attrs...), Value: 4},
+						{Attributes: attrs, Value: 4},
 						{Value: 11},
 					},
 				},
@@ -899,9 +899,9 @@ func testAttributeFilter(temporality metricdata.Temporality) func(*testing.T) {
 					return err
 				}
 				_, err = mtr.RegisterCallback(func(_ context.Context, o metric.Observer) error {
-					o.ObserveFloat64(ctr, 1.0, attribute.String("foo", "bar"), attribute.Int("version", 1))
-					o.ObserveFloat64(ctr, 2.0, attribute.String("foo", "bar"))
-					o.ObserveFloat64(ctr, 1.0, attribute.String("foo", "bar"), attribute.Int("version", 2))
+					o.ObserveFloat64(ctr, 1.0, instrument.WithAttributes[float64](attribute.String("foo", "bar"), attribute.Int("version", 1)))
+					o.ObserveFloat64(ctr, 2.0, instrument.WithAttributes[float64](attribute.String("foo", "bar")))
+					o.ObserveFloat64(ctr, 1.0, instrument.WithAttributes[float64](attribute.String("foo", "bar"), attribute.Int("version", 2)))
 					return nil
 				}, ctr)
 				return err
@@ -928,9 +928,9 @@ func testAttributeFilter(temporality metricdata.Temporality) func(*testing.T) {
 					return err
 				}
 				_, err = mtr.RegisterCallback(func(_ context.Context, o metric.Observer) error {
-					o.ObserveFloat64(ctr, 1.0, attribute.String("foo", "bar"), attribute.Int("version", 1))
-					o.ObserveFloat64(ctr, 2.0, attribute.String("foo", "bar"))
-					o.ObserveFloat64(ctr, 1.0, attribute.String("foo", "bar"), attribute.Int("version", 2))
+					o.ObserveFloat64(ctr, 1.0, instrument.WithAttributes[float64](attribute.String("foo", "bar"), attribute.Int("version", 1)))
+					o.ObserveFloat64(ctr, 2.0, instrument.WithAttributes[float64](attribute.String("foo", "bar")))
+					o.ObserveFloat64(ctr, 1.0, instrument.WithAttributes[float64](attribute.String("foo", "bar"), attribute.Int("version", 2)))
 					return nil
 				}, ctr)
 				return err
@@ -957,8 +957,8 @@ func testAttributeFilter(temporality metricdata.Temporality) func(*testing.T) {
 					return err
 				}
 				_, err = mtr.RegisterCallback(func(_ context.Context, o metric.Observer) error {
-					o.ObserveFloat64(ctr, 1.0, attribute.String("foo", "bar"), attribute.Int("version", 1))
-					o.ObserveFloat64(ctr, 2.0, attribute.String("foo", "bar"), attribute.Int("version", 2))
+					o.ObserveFloat64(ctr, 1.0, instrument.WithAttributes[float64](attribute.String("foo", "bar"), attribute.Int("version", 1)))
+					o.ObserveFloat64(ctr, 2.0, instrument.WithAttributes[float64](attribute.String("foo", "bar"), attribute.Int("version", 2)))
 					return nil
 				}, ctr)
 				return err
@@ -983,9 +983,9 @@ func testAttributeFilter(temporality metricdata.Temporality) func(*testing.T) {
 					return err
 				}
 				_, err = mtr.RegisterCallback(func(_ context.Context, o metric.Observer) error {
-					o.ObserveInt64(ctr, 10, attribute.String("foo", "bar"), attribute.Int("version", 1))
-					o.ObserveInt64(ctr, 20, attribute.String("foo", "bar"))
-					o.ObserveInt64(ctr, 10, attribute.String("foo", "bar"), attribute.Int("version", 2))
+					o.ObserveInt64(ctr, 10, instrument.WithAttributes[int64](attribute.String("foo", "bar"), attribute.Int("version", 1)))
+					o.ObserveInt64(ctr, 20, instrument.WithAttributes[int64](attribute.String("foo", "bar")))
+					o.ObserveInt64(ctr, 10, instrument.WithAttributes[int64](attribute.String("foo", "bar"), attribute.Int("version", 2)))
 					return nil
 				}, ctr)
 				return err
@@ -1012,9 +1012,9 @@ func testAttributeFilter(temporality metricdata.Temporality) func(*testing.T) {
 					return err
 				}
 				_, err = mtr.RegisterCallback(func(_ context.Context, o metric.Observer) error {
-					o.ObserveInt64(ctr, 10, attribute.String("foo", "bar"), attribute.Int("version", 1))
-					o.ObserveInt64(ctr, 20, attribute.String("foo", "bar"))
-					o.ObserveInt64(ctr, 10, attribute.String("foo", "bar"), attribute.Int("version", 2))
+					o.ObserveInt64(ctr, 10, instrument.WithAttributes[int64](attribute.String("foo", "bar"), attribute.Int("version", 1)))
+					o.ObserveInt64(ctr, 20, instrument.WithAttributes[int64](attribute.String("foo", "bar")))
+					o.ObserveInt64(ctr, 10, instrument.WithAttributes[int64](attribute.String("foo", "bar"), attribute.Int("version", 2)))
 					return nil
 				}, ctr)
 				return err
@@ -1041,8 +1041,8 @@ func testAttributeFilter(temporality metricdata.Temporality) func(*testing.T) {
 					return err
 				}
 				_, err = mtr.RegisterCallback(func(_ context.Context, o metric.Observer) error {
-					o.ObserveInt64(ctr, 10, attribute.String("foo", "bar"), attribute.Int("version", 1))
-					o.ObserveInt64(ctr, 20, attribute.String("foo", "bar"), attribute.Int("version", 2))
+					o.ObserveInt64(ctr, 10, instrument.WithAttributes[int64](attribute.String("foo", "bar"), attribute.Int("version", 1)))
+					o.ObserveInt64(ctr, 20, instrument.WithAttributes[int64](attribute.String("foo", "bar"), attribute.Int("version", 2)))
 					return nil
 				}, ctr)
 				return err
@@ -1067,8 +1067,8 @@ func testAttributeFilter(temporality metricdata.Temporality) func(*testing.T) {
 					return err
 				}
 
-				ctr.Add(context.Background(), 1.0, attribute.String("foo", "bar"), attribute.Int("version", 1))
-				ctr.Add(context.Background(), 2.0, attribute.String("foo", "bar"), attribute.Int("version", 2))
+				ctr.Add(context.Background(), 1.0, instrument.WithAttributes[float64](attribute.String("foo", "bar"), attribute.Int("version", 1)))
+				ctr.Add(context.Background(), 2.0, instrument.WithAttributes[float64](attribute.String("foo", "bar"), attribute.Int("version", 2)))
 				return nil
 			},
 			wantMetric: metricdata.Metrics{
@@ -1093,8 +1093,8 @@ func testAttributeFilter(temporality metricdata.Temporality) func(*testing.T) {
 					return err
 				}
 
-				ctr.Add(context.Background(), 1.0, attribute.String("foo", "bar"), attribute.Int("version", 1))
-				ctr.Add(context.Background(), 2.0, attribute.String("foo", "bar"), attribute.Int("version", 2))
+				ctr.Add(context.Background(), 1.0, instrument.WithAttributes[float64](attribute.String("foo", "bar"), attribute.Int("version", 1)))
+				ctr.Add(context.Background(), 2.0, instrument.WithAttributes[float64](attribute.String("foo", "bar"), attribute.Int("version", 2)))
 				return nil
 			},
 			wantMetric: metricdata.Metrics{
@@ -1119,8 +1119,8 @@ func testAttributeFilter(temporality metricdata.Temporality) func(*testing.T) {
 					return err
 				}
 
-				ctr.Record(context.Background(), 1.0, attribute.String("foo", "bar"), attribute.Int("version", 1))
-				ctr.Record(context.Background(), 2.0, attribute.String("foo", "bar"), attribute.Int("version", 2))
+				ctr.Record(context.Background(), 1.0, instrument.WithAttributes[float64](attribute.String("foo", "bar"), attribute.Int("version", 1)))
+				ctr.Record(context.Background(), 2.0, instrument.WithAttributes[float64](attribute.String("foo", "bar"), attribute.Int("version", 2)))
 				return nil
 			},
 			wantMetric: metricdata.Metrics{
@@ -1149,8 +1149,8 @@ func testAttributeFilter(temporality metricdata.Temporality) func(*testing.T) {
 					return err
 				}
 
-				ctr.Add(context.Background(), 10, attribute.String("foo", "bar"), attribute.Int("version", 1))
-				ctr.Add(context.Background(), 20, attribute.String("foo", "bar"), attribute.Int("version", 2))
+				ctr.Add(context.Background(), 10, instrument.WithAttributes[int64](attribute.String("foo", "bar"), attribute.Int("version", 1)))
+				ctr.Add(context.Background(), 20, instrument.WithAttributes[int64](attribute.String("foo", "bar"), attribute.Int("version", 2)))
 				return nil
 			},
 			wantMetric: metricdata.Metrics{
@@ -1175,8 +1175,8 @@ func testAttributeFilter(temporality metricdata.Temporality) func(*testing.T) {
 					return err
 				}
 
-				ctr.Add(context.Background(), 10, attribute.String("foo", "bar"), attribute.Int("version", 1))
-				ctr.Add(context.Background(), 20, attribute.String("foo", "bar"), attribute.Int("version", 2))
+				ctr.Add(context.Background(), 10, instrument.WithAttributes[int64](attribute.String("foo", "bar"), attribute.Int("version", 1)))
+				ctr.Add(context.Background(), 20, instrument.WithAttributes[int64](attribute.String("foo", "bar"), attribute.Int("version", 2)))
 				return nil
 			},
 			wantMetric: metricdata.Metrics{
@@ -1201,8 +1201,8 @@ func testAttributeFilter(temporality metricdata.Temporality) func(*testing.T) {
 					return err
 				}
 
-				ctr.Record(context.Background(), 1, attribute.String("foo", "bar"), attribute.Int("version", 1))
-				ctr.Record(context.Background(), 2, attribute.String("foo", "bar"), attribute.Int("version", 2))
+				ctr.Record(context.Background(), 1, instrument.WithAttributes[int64](attribute.String("foo", "bar"), attribute.Int("version", 1)))
+				ctr.Record(context.Background(), 2, instrument.WithAttributes[int64](attribute.String("foo", "bar"), attribute.Int("version", 2)))
 				return nil
 			},
 			wantMetric: metricdata.Metrics{
@@ -1297,7 +1297,7 @@ func TestObservableExample(t *testing.T) {
 		_, err := meter.Int64ObservableCounter(instName, instrument.WithCallback[int64](
 			func(_ context.Context, o instrument.ObserverT[int64]) error {
 				for attrSet, val := range observations {
-					o.Observe(val, attrSet.ToSlice()...)
+					o.Observe(val, instrument.WithAttributeSet[int64](attrSet))
 				}
 				return nil
 			},


### PR DESCRIPTION
This changes the Add/Record/Observe to use a generic option type, eg. `AddOption[N]`.  This has comparable benchmarks to https://github.com/open-telemetry/opentelemetry-go/pull/3971 if you don't include preallocating attributes.

What is not explored is if the Options need to be generic.  It would be possible to just have an `AddOption`, but that would prevent the future option that differed based on int64 vs float64.  This might not be a problem because that option would be required to be generic, meaning you couldn't do different steps if the option itself was Int64 or Float64.